### PR TITLE
Fix bug preventing artifact upload vi DataConfig

### DIFF
--- a/ci_watson/artifactory_helpers.py
+++ b/ci_watson/artifactory_helpers.py
@@ -534,7 +534,7 @@ def generate_upload_params(results_root, updated_outputs, verbose=True):
     # Write out JSON file to enable retention of different results.
     # Also rename outputs as new truths.
     for files in updated_outputs:
-        new_truth = os.path.basename(files[1])
+        new_truth = os.path.abspath(files[1])
         schema_pattern.append(new_truth)
         shutil.move(files[0], new_truth)
         if verbose:

--- a/ci_watson/artifactory_helpers.py
+++ b/ci_watson/artifactory_helpers.py
@@ -533,13 +533,13 @@ def generate_upload_params(results_root, updated_outputs, verbose=True):
 
     # Write out JSON file to enable retention of different results.
     # Also rename outputs as new truths.
-    for files in updated_outputs:
-        new_truth = os.path.abspath(files[1])
-        schema_pattern.append(new_truth)
-        shutil.move(files[0], new_truth)
+    for test_result, truth in updated_outputs:
+        new_truth = os.path.basename(truth)
+        shutil.move(test_result, new_truth)
+        schema_pattern.append(os.path.abspath(new_truth))
         if verbose:
             print("Renamed {} as new 'truth' file: {}".format(
-                files[0], new_truth))
+                os.path.abspath(test_result), os.path.abspath(new_truth)))
 
     return schema_pattern, tree, testname
 

--- a/tests/test_artifactory_helpers.py
+++ b/tests/test_artifactory_helpers.py
@@ -302,7 +302,7 @@ class TestGenerateUploadParams:
         schema_pattern, tree, testname = generate_upload_params(
             'groot', updated_outputs, verbose=False)
 
-        assert schema_pattern == ['*.log', 'desired.txt']
+        assert schema_pattern == ['*.log', os.path.abspath('desired.txt')]
         assert isinstance(testname, str)  # Actual value non-deterministic
 
         # TODO: Use regex?


### PR DESCRIPTION
The absolute path is needed in the JSON file to upload failed Jenkins test results to Artifactory storage area.