### PR TITLE
Use ISO format datetime set at beginning of build

### DIFF
--- a/ci_watson/artifactory_helpers.py
+++ b/ci_watson/artifactory_helpers.py
@@ -2,7 +2,7 @@
 Helpers for Artifactory or local big data handling.
 """
 import copy
-import datetime
+from datetime import datetime
 import json
 import os
 import re
@@ -38,6 +38,8 @@ UPLOAD_SCHEMA = {"files": [
                      "regexp": "false",
                      "explode": "false",
                      "excludePatterns": []}]}
+
+TIME_NOW = datetime.now()
 
 
 class BigdataError(Exception):
@@ -515,21 +517,20 @@ def generate_upload_params(results_root, updated_outputs, verbose=True):
 
     # Create instructions for uploading results to artifactory for use
     # as new comparison/truth files
-    time_now = datetime.datetime.now()
     testname = os.path.split(os.path.abspath(os.curdir))[1]
 
     # Meaningful test dir from build info.
     # TODO: Organize results by day test was run. Could replace with git-hash
     whoami = getpass.getuser() or 'nobody'
-    ttime = time_now.strftime("%H_%M_%S")
-    user_tag = 'NOT_CI_{}_{}'.format(whoami, ttime)
+    user_tag = 'NOT_CI_{}'.format(whoami)
     build_tag = os.environ.get('BUILD_TAG', user_tag)
-    build_suffix = os.environ.get('BUILD_MATRIX_SUFFIX', 'standalone')
-    testdir = "{}_{}_{}".format(testname, build_tag, build_suffix)
-
-    dt = time_now.strftime("%d%b%YT")
-    tree = os.path.join(results_root, dt, testdir) + os.sep
-    schema_pattern = ['*.log']
+    date = TIME_NOW.strftime("%Y-%m-%d")
+    build_matrix_suffix = os.environ.get('BUILD_MATRIX_SUFFIX', '0')
+    subdir = '{}_{}_{}'.format(date, build_tag, build_matrix_suffix)
+    tree = os.path.join(results_root, subdir, testname) + os.sep
+    schema_pattern = []
+    # Upload all log files
+    schema_pattern.append('*.log')
 
     # Write out JSON file to enable retention of different results.
     # Also rename outputs as new truths.

--- a/ci_watson/artifactory_helpers.py
+++ b/ci_watson/artifactory_helpers.py
@@ -39,7 +39,7 @@ UPLOAD_SCHEMA = {"files": [
                      "explode": "false",
                      "excludePatterns": []}]}
 
-TIME_NOW = datetime.now()
+TODAYS_DATE = datetime.now().strftime("%Y-%m-%d")
 
 
 class BigdataError(Exception):
@@ -524,9 +524,8 @@ def generate_upload_params(results_root, updated_outputs, verbose=True):
     whoami = getpass.getuser() or 'nobody'
     user_tag = 'NOT_CI_{}'.format(whoami)
     build_tag = os.environ.get('BUILD_TAG', user_tag)
-    date = TIME_NOW.strftime("%Y-%m-%d")
     build_matrix_suffix = os.environ.get('BUILD_MATRIX_SUFFIX', '0')
-    subdir = '{}_{}_{}'.format(date, build_tag, build_matrix_suffix)
+    subdir = '{}_{}_{}'.format(TODAYS_DATE, build_tag, build_matrix_suffix)
     tree = os.path.join(results_root, subdir, testname) + os.sep
     schema_pattern = []
     # Upload all log files

--- a/tests/test_artifactory_helpers.py
+++ b/tests/test_artifactory_helpers.py
@@ -308,7 +308,7 @@ class TestGenerateUploadParams:
         # TODO: Use regex?
         split_tree = tree.split(os.sep)
         assert split_tree[0] == 'groot'
-        assert split_tree[2].endswith('_tag0_foo')
+        assert split_tree[1].endswith('_tag0_foo')
         assert split_tree[3] == ''
 
         # Make sure file is moved properly.


### PR DESCRIPTION
These are the modifications I've made on the JWST side.  I think having ISO format `datetime` makes them more easily sorted in the results.  And having the matrix and build info in the build directory instead of attached to each test directory makes sense for us too - less repeating information, and more easily-mapped output dir name to test name.

The proposed format:
```
repo-info
     \_______date-build-matrix-info
                      \_______________test-info
```
Before the results repo was organized like:
```
01Dec2018T/test_nrs_fs_multi_spec2_test_n0_jenkins-RT-JWST-60_standalone/
01Nov2018T/test_nrs_fs_multi_spec2_test_n0_jenkins-RT-JWST-24_standalone/
```
Now one gets:
```
2018-11-01_jenkins-RT-JWST-24_0/test_nrs_fs_multi_spec2_test_n0
2018-12-01_jenkins-RT-JWST-60_0/test_nrs_fs_multi_spec2_test_n0
```

The `datetime` was pulled into a global variable as for `jwst`, our regregression test runs take over 3 hours, and if they kick off at 11pm, `generate_upload_params()` could get called spanning 2 days, which means the same test run would get split over two directories based on two `datetimes`.  Better to have all results in one output dir.