### PR TITLE
Make Artifactory upload spec files human-readable JSON

### DIFF
--- a/ci_watson/artifactory_helpers.py
+++ b/ci_watson/artifactory_helpers.py
@@ -596,4 +596,4 @@ def generate_upload_schema(pattern, target, testname, recursive=False):
 
     # Write out JSON file with description of test results
     with open(jsonfile, 'w') as outfile:
-        json.dump(upload_schema, outfile)
+        json.dump(upload_schema, outfile, indent=2)


### PR DESCRIPTION
If a test fails, a JSON upload spec file can be generated using the functions `generate_upload_schema()` and `generate_upload_params()` in order to push the failed results to Artifactory.  This is currently not very human-readable.

Since these files are small and get overwritten when new tests are run, it would be useful to have them be more human-readable.

So an Artifactory upload spec file for a failed test currently looks like:
```
{"files": [{"pattern": "/Users/jdavies/scratch/test_miri_lrs_bkgnod0/test_lrs1_bsub.fits", "target": "jwst-pipeline-results/2019-01-03_NOT_CI_jdavies_0/test_miri_lrs_bkgnod0/", "props": null, "recursive": "false", "flat": "true", "regexp": "false", "explode": "false", "excludePatterns": []}]}
```
This PR would change it to:
```
{
  "files": [
    {
      "pattern": "/Users/jdavies/scratch/test_miri_lrs_bkgnod0/test_lrs1_bsub.fits",
      "target": "jwst-pipeline-results/2019-01-03_NOT_CI_jdavies_0/test_miri_lrs_bkgnod0/",
      "props": null,
      "recursive": "false",
      "flat": "true",
      "regexp": "false",
      "explode": "false",
      "excludePatterns": []
    }
  ]
}
```