### PR TITLE
Add ini file options for data root locations

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -62,7 +62,6 @@ def pytest_configure(config):
         os.environ["CIWATSON_RESULTS_ROOT"] = config.getini('results_root')[0]
 
 
-
 def pytest_runtest_setup(item):
     if 'slow' in item.keywords and not item.config.getvalue("slow"):
         pytest.skip("need --slow option to run")

--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -36,13 +36,15 @@ def pytest_addoption(parser):
     )
 
     # Data file input/output source/destination customization.
-    parser.addini("inputs_root",
+    parser.addini(
+        "inputs_root",
         "Root dir (or data repository name) for test input files.",
         type="args",
         default=None,
     )
 
-    parser.addini("results_root",
+    parser.addini(
+        "results_root",
         "Root dir (or data repository name) for test result/output files.",
         type="args",
         default=None,

--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -35,6 +35,19 @@ def pytest_addoption(parser):
         help="specify what environment to test"
     )
 
+    # Data file input/output source/destination customization.
+    parser.addini("inputs_root",
+        "Root dir (or data repository name) for test input files.",
+        type="args",
+        default=None,
+    )
+
+    parser.addini("results_root",
+        "Root dir (or data repository name) for test result/output files.",
+        type="args",
+        default=None,
+    )
+
 
 def pytest_configure(config):
     config.getini('markers').append(
@@ -42,6 +55,12 @@ def pytest_configure(config):
 
     config.getini('markers').append(
         'bigdata: Run tests that require intranet access')
+
+    if config.getini('inputs_root'):
+        os.environ["CIWATSON_INPUTS_ROOT"] = config.getini('inputs_root')[0]
+    if config.getini('results_root'):
+        os.environ["CIWATSON_RESULTS_ROOT"] = config.getini('results_root')[0]
+
 
 
 def pytest_runtest_setup(item):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,16 +34,33 @@ The plugin portion of ``ci_watson`` contains:
   the author of the test to use this environment setting properly.
 * ``_jail`` fixture to enable a test to run in a pristine temporary working
   directory. This is particularly useful for pipeline tests.
-* Optional ``pytest.ini``/``setup.cfg [tool:pytest]`` configuration items
-  ``inputs_root``/``results_root`` - The 'bigdata' remote repository name/local
-  data root directory for testing input/output files. Setting the value of
-  either option will define the corresponding environment variable during
-  test execution.  This environment variable may be used by test code to
-  obtain the name of the artifactory repository/local data root directory to
-  use when accessing locations needed for running tests.
+  
+Configuration Options
 
-  * ``inputs_root`` - Environment variable: ``CIWATSON_INPUTS_ROOT``.
-  * ``results_root`` - Environment variable: ``CIWATSON_RESULTS_ROOT``.
+``inputs_root``/``results_root`` - The 'bigdata' remote repository name/local
+data root directory for testing input/output files. Setting the value of
+either option will define the corresponding environment variable during
+test execution.  This environment variable may be used by test code to
+obtain the name of the artifactory repository/local data root directory to
+use when accessing locations needed for running tests.
+
+Note: If used, these values should appear in either ``pytest.ini`` OR the appropriate
+section in ``setup.cfg``, *not both*.
+
+* ``inputs_root`` sets environment variable ``CIWATSON_INPUTS_ROOT``.
+* ``results_root`` sets environment variable ``CIWATSON_RESULTS_ROOT``.
+
+Example use within ``setup.cfg``::
+
+  [tool:pytest]
+  inputs_root = my_data_repo
+  results_root = my_results_repo
+
+Example use within ``pytest.ini``::
+
+  [pytest]
+  inputs_root = my_data_repo
+  results_root = my_results_repo
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,7 +63,6 @@ Example use within ``pytest.ini``::
   results_root = my_results_repo
 
 
-
 .. _bigdata_setup:
 
 Setting Up For Big Data

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,17 @@ The plugin portion of ``ci_watson`` contains:
   the author of the test to use this environment setting properly.
 * ``_jail`` fixture to enable a test to run in a pristine temporary working
   directory. This is particularly useful for pipeline tests.
+* Optional ``pytest.ini``/``setup.cfg [tool:pytest]`` configuration items
+  ``inputs_root``/``results_root`` - The 'bigdata' remote repository name/local
+  data root directory for testing input/output files. Setting the value of
+  either option will define the corresponding environment variable during
+  test execution.  This environment variable may be used by test code to
+  obtain the name of the artifactory repository/local data root directory to
+  use when accessing locations needed for running tests.
+
+  * ``inputs_root`` - Environment variable: ``CIWATSON_INPUTS_ROOT``.
+  * ``results_root`` - Environment variable: ``CIWATSON_RESULTS_ROOT``.
+
 
 
 .. _bigdata_setup:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ The plugin portion of ``ci_watson`` contains:
   directory. This is particularly useful for pipeline tests.
   
 Configuration Options
+---------------------
 
 ``inputs_root``/``results_root`` - The 'bigdata' remote repository name/local
 data root directory for testing input/output files. Setting the value of

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
 [tool:pytest]
 minversion = 3
 norecursedirs = .eggs build relic
+inputs_root = ci-watson
 
 [flake8]
 exclude = setup.py,relic,conf.py

--- a/tests/test_artifactory_helpers.py
+++ b/tests/test_artifactory_helpers.py
@@ -59,7 +59,10 @@ class TestGetBigdata:
         self.root = get_bigdata_root()
 
     def test_nocopy(self, _jail):
-        args = ('ci-watson', 'dev', 'input', 'j6lq01010_asn.fits')
+        args = (os.environ['CIWATSON_INPUTS_ROOT'],
+                'dev',
+                'input',
+                'j6lq01010_asn.fits')
         dest = get_bigdata(*args, docopy=False)
         assert dest == os.path.abspath(os.path.join(self.root, *args))
         assert len(os.listdir()) == 0
@@ -74,7 +77,10 @@ class TestGetBigdata:
         This tests download when TEST_BIGDATA is pointing to Artifactory.
         And tests copy when it is pointing to local path.
         """
-        args = ('ci-watson', 'dev', 'input', 'j6lq01010_asn.fits')
+        args = (os.environ['CIWATSON_INPUTS_ROOT'],
+                'dev',
+                'input',
+                'j6lq01010_asn.fits')
         dest = get_bigdata(*args)
         assert dest == os.path.abspath(os.path.join(os.curdir, args[-1]))
 


### PR DESCRIPTION
Allow for `pytest.ini` or `setup.cfg [tool:pytest]` configuration of the Artifactory repo/local data root directory for test inputs and outputs.