### PR TITLE
Simpler passing of pytest config values to tests.

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -58,11 +58,6 @@ def pytest_configure(config):
     config.getini('markers').append(
         'bigdata: Run tests that require intranet access')
 
-    if config.getini('inputs_root'):
-        os.environ["CIWATSON_INPUTS_ROOT"] = config.getini('inputs_root')[0]
-    if config.getini('results_root'):
-        os.environ["CIWATSON_RESULTS_ROOT"] = config.getini('results_root')[0]
-
 
 def pytest_runtest_setup(item):
     if 'slow' in item.keywords and not item.config.getvalue("slow"):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,28 +40,34 @@ Configuration Options
 
 ``inputs_root``/``results_root`` - The 'bigdata' remote repository name/local
 data root directory for testing input/output files. Setting the value of
-either option will define the corresponding environment variable during
-test execution.  This environment variable may be used by test code to
-obtain the name of the artifactory repository/local data root directory to
-use when accessing locations needed for running tests.
+either option will make it availble to tests via the ``pytestconfig`` fixture.
+Test code can then obtain the name of the artifactory repository/local data
+root directory to use when accessing locations needed for running tests.
 
 Note: If used, these values should appear in either ``pytest.ini`` OR the appropriate
 section in ``setup.cfg``, *not both*.
 
-* ``inputs_root`` sets environment variable ``CIWATSON_INPUTS_ROOT``.
-* ``results_root`` sets environment variable ``CIWATSON_RESULTS_ROOT``.
-
-Example use within ``setup.cfg``::
+Example configuration within ``setup.cfg``::
 
   [tool:pytest]
   inputs_root = my_data_repo
   results_root = my_results_repo
 
-Example use within ``pytest.ini``::
+Example configuration within ``pytest.ini``::
 
   [pytest]
   inputs_root = my_data_repo
   results_root = my_results_repo
+
+The value(s) defined in the pytest configuration file may be accessed as a list
+by test code via the ``pytestconfig`` fixture which must be passed in as an
+argument to the test method or function that will use the value.
+
+Example of accessing configuration values within tests::
+
+  def test_important_thing(pytestconfig):
+      setup_cfg_inputs_root = pytestconfig.getini('inputs_root')[0]
+      assert setup_cfg_inputs_root == 'my_data_repo'
 
 
 .. _bigdata_setup:

--- a/tests/test_artifactory_helpers.py
+++ b/tests/test_artifactory_helpers.py
@@ -58,8 +58,8 @@ class TestGetBigdata:
     def setup_class(self):
         self.root = get_bigdata_root()
 
-    def test_nocopy(self, _jail):
-        args = (os.environ['CIWATSON_INPUTS_ROOT'],
+    def test_nocopy(self, _jail, pytestconfig):
+        args = (pytestconfig.getini('inputs_root')[0],
                 'dev',
                 'input',
                 'j6lq01010_asn.fits')
@@ -72,12 +72,12 @@ class TestGetBigdata:
         with pytest.raises(BigdataError):
             get_bigdata('fake', 'path', 'somefile.txt', docopy=docopy)
 
-    def test_get_data(self, _jail):
+    def test_get_data(self, _jail, pytestconfig):
         """
         This tests download when TEST_BIGDATA is pointing to Artifactory.
         And tests copy when it is pointing to local path.
         """
-        args = (os.environ['CIWATSON_INPUTS_ROOT'],
+        args = (pytestconfig.getini('inputs_root')[0],
                 'dev',
                 'input',
                 'j6lq01010_asn.fits')


### PR DESCRIPTION
Reverts #29, and instead passes configuration values entirely within pytest to the testing code that requests it.