### PR TITLE
Update index.rst with another example

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,12 +63,16 @@ The value(s) defined in the pytest configuration file may be accessed as a list
 by test code via the ``pytestconfig`` fixture which must be passed in as an
 argument to the test method or function that will use the value.
 
-Example of accessing configuration values within tests::
+Example of accessing configuration values within test code itself::
 
   def test_important_thing(pytestconfig):
       setup_cfg_inputs_root = pytestconfig.getini('inputs_root')[0]
       assert setup_cfg_inputs_root == 'my_data_repo'
+      
+From within a fixture or a test class the configuration values must be accessed using a slightly different approach.::
 
+Example:
+    inputs_root = pytest.config.getini('inputs_root')[0]
 
 .. _bigdata_setup:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,7 @@ Example of accessing configuration values within test code itself::
       
 From within a fixture or a test class the configuration values must be accessed using a slightly different approach::
 
+    import pytest
     inputs_root = pytest.config.getini('inputs_root')[0]
 
 .. _bigdata_setup:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,9 +69,8 @@ Example of accessing configuration values within test code itself::
       setup_cfg_inputs_root = pytestconfig.getini('inputs_root')[0]
       assert setup_cfg_inputs_root == 'my_data_repo'
       
-From within a fixture or a test class the configuration values must be accessed using a slightly different approach.::
+From within a fixture or a test class the configuration values must be accessed using a slightly different approach::
 
-Example:
     inputs_root = pytest.config.getini('inputs_root')[0]
 
 .. _bigdata_setup:


### PR DESCRIPTION
Add example for accessing pytest configuration values from within fixtures or test classes.