### PR TITLE
Allow --env values other than 'dev' and 'stable'

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -30,8 +30,7 @@ def pytest_addoption(parser):
     # Choose to test under dev or stable
     parser.addoption(
         "--env",
-        choices=['dev', 'stable'],
-        default='dev',
+        default="dev",
         help="specify what environment to test"
     )
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -5,7 +5,6 @@ import pytest
 def test_envopt(pytestconfig, envopt):
     """Test ``envopt`` fixture that is tied to ``--env`` option."""
     input_env = pytestconfig.getoption('env')
-    assert input_env in ('dev', 'stable')
     assert envopt == input_env
 
 


### PR DESCRIPTION
Currently the plugin only allows
```
pytest --env=dev
pytest --env=stable
```
Where `env` is not really an environment, but really allows one to map a `--bigdata` repo that corresponds to a development branch or stable branch.  But it would also be very useful to not only select between `dev` and `stable`, but also a named branch or tag.  So
```
pytest --env=0.13.4
pytest --env=my_branch
```
would be very useful.  Sometimes `stable` is not enough, and I want to go back to a specific stable branch or tag.

This implements that.