### PR TITLE
Change envopt fixture to be session-scoped

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -77,7 +77,7 @@ def _jail(tmpdir):
         os.chdir(old_dir)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def envopt(request):
-    """Get the environment to test."""
+    """Get the ``--env`` command-line option specifying test environment"""
     return request.config.getoption("env")


### PR DESCRIPTION
Changing the `envopt` fixture to be session-scoped, as it returns a command-line option that can only session-scoped.

This will allow it to be used in other session-, module-, class- or function-scoped fixtures.  Currently, it can only be used in function-scoped fixtures.

Fixes #33.