### PR TITLE
Add slow and bigdata fixtures for test access

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -77,7 +77,23 @@ def _jail(tmpdir):
         os.chdir(old_dir)
 
 
+@pytest.fixture
+def bigdata(request):
+    """Setup bigdata fixture for tests to identify if --slow
+    has been specified
+    """
+    return request.config.getoption('--bigdata')
+
+
 @pytest.fixture(scope='session')
 def envopt(request):
     """Get the ``--env`` command-line option specifying test environment"""
     return request.config.getoption("env")
+
+
+@pytest.fixture
+def slow(request):
+    """Setup slow fixture for tests to identify if --slow
+    has been specified
+    """
+    return request.config.getoption('--slow')


### PR DESCRIPTION
Add `slow` and `bigdata` fixtures so test can have access to the options after collection. This allows the form

```
def test_but_change_on_slow(slow):
    ...
    if slow:
        ....
```