### PR TITLE
Return the CWD of the _jail fixture as a string

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -72,7 +72,7 @@ def _jail(tmpdir):
     old_dir = os.getcwd()
     os.chdir(tmpdir.strpath)
     try:
-        yield
+        yield tmpdir.strpath
     finally:
         os.chdir(old_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,12 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=[
-        'pytest>=3'
+        'pytest>=3',
+        'requests',
     ],
+    extras_require={
+        'test': ['astropy']
+    },
     python_requires='>=3.5',
     entry_points={
         'pytest11': [

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -46,3 +46,11 @@ class TestJail:
     def test_notintemppostjail(self):
         """Ensure that start state was recovered"""
         assert os.getcwd() == self.cwd
+
+
+def test_get_jail_as_string(_jail):
+    """Test that the _jail fixture returns the cwd as a string"""
+    cwd = os.getcwd()
+    cwd_jail = _jail
+
+    assert cwd == cwd_jail


### PR DESCRIPTION
This is useful for a test to know where it is being run, and is based on similar functionality in the built-in pytest fixtures `tmpdir`, `tmp_path`, `tmpdir_factory`, `tmp_path_factory`.

Also:

 - Add `requests` to the dependency list, as it is a dependency of the package and is not currently listed.

- Make the test dependencies easy to install by adding a `[test]` section to `extras_require`.