### PR TITLE
Fix compare_outputs test

### DIFF
--- a/tests/test_artifactory_helpers.py
+++ b/tests/test_artifactory_helpers.py
@@ -195,90 +195,10 @@ class TestCompareOutputs:
         report = compare_outputs(
             outputs, input_path=self.inpath, docopy=self.copy,
             verbose=False, raise_error=False)
-        s = report.split(os.linesep)
 
-        # NOTE: Update as needed from running this test case manually and
-        #       paste expected "s" here as "expected".
-        #       Then, exclude the lines from comparison by inserting "...".
-        #       This is not fool-proof but easier to maintain.
-        expected = [
-            '',
-            ' fitsdiff: ...',
-            ' a: j6lq01010_asn.fits',
-            ' b: .../input/j6lq01010_asn.fits',
-            ' Maximum number of different data values to be reported: 10',
-            ' Relative tolerance: 0.0, Absolute tolerance: 0.0',
-            '',
-            'No differences found.',
-            '',
-            'a: j6lq01010_asn.fits[asn]',
-            'b: .../input/j6lq01010_asn.fits[ASN]',
-            ' No differences found.',
-            '',
-            'a: j6lq01010_asn.fits[image]',
-            'b: .../input/j6lq01010_asn_mod.fits[IMAGE]',
-            ' No differences found.',
-            '',
-            'a: j6lq01010_asn.fits',
-            'b: .../input/j6lq01010_asn_mod.fits',
-            '',
-            ' fitsdiff: ...',
-            ' a: <HDUList object at ...>',
-            ' b: <HDUList object at ...>',
-            ' Maximum number of different data values to be reported: 10',
-            ' Relative tolerance: 1e-07, Absolute tolerance: 0.05',
-            '',
-            'No differences found.',
-            '',
-            'a: j6lq01010_asn.txt',
-            'b: .../input/j6lq01010_asn.txt',
-            'No differences found.',
-            '',
-            'a: j6lq01010_asn.fits',
-            'b: .../input/j6lq01010_asn_mod.fits',
-            '',
-            ' fitsdiff: ...',
-            ' a: <HDUList object at ...>',
-            ' b: <HDUList object at ...>',
-            ' Maximum number of different data values to be reported: 10',
-            ' Relative tolerance: 0.0, Absolute tolerance: 0.0',
-            '',
-            'Extension HDU 1:',
-            '',
-            '   Data contains differences:',
-            '     Data differs at [1, 1]:',
-            '...     a> 0.6085371124054807',
-            '...      ?    ^',
-            '...     b> 0.6585371124054807',
-            '...      ?    ^',
-            '     Data differs at [2, 1]:',
-            '...     a> 0.36385821035372456',
-            '...      ?   ^^              ^',
-            '...     b> 0.41385821035372455',
-            '...      ?   ^^              ^',
-            '     Data differs at [1, 2]:',
-            '...     a> 0.40339636497834697',
-            '...      ?    ^              ^',
-            '...     b> 0.45339636497834696',
-            '...      ?    ^              ^',
-            '     Data differs at [2, 2]:',
-            '...     a> 0.40104384147076577',
-            '...      ?    ^              ^',
-            '...     b> 0.45104384147076576',
-            '...      ?    ^              ^',
-            '     4 different pixels found (100.00% different).',
-            '',
-            'a: j6lq01010_asn.txt',
-            'b: .../input/j6lq01010_asn.txt',
-            'No differences found.',
-            '']
-
-        assert len(s) == len(expected), 'Mismatch on expected number of lines'
-
-        for sl, el in zip(s, expected):
-            if '...' in el:
-                continue
-            assert sl == el
+        # There are 7 comparisons, and only 1 should show a difference
+        assert report.count("No differences found") == 6
+        assert report.count("different pixels found") == 1
 
 
 class TestGenerateUploadParams:


### PR DESCRIPTION
Fixes issue currently seen in the tests against dev `astropy`.

```
>           assert sl == el
E           AssertionError: assert 'Extension HDU 1 (IMAGE, 1):' == 'Extension HDU 1:'
E             - Extension HDU 1:
E             + Extension HDU 1 (IMAGE, 1):

../../tests/test_artifactory_helpers.py:281: AssertionError
```

Resolves #46