### PR TITLE
Use CRDS sync instead of informal URL for HST reffile downloads

### DIFF
--- a/ci_watson/hst_helpers.py
+++ b/ci_watson/hst_helpers.py
@@ -12,6 +12,7 @@ __all__ = ['ref_from_image', 'raw_from_asn', 'download_crds']
 CRDS_SERVER_URL = "https://hst-crds.stsci.edu"
 HST_INSTRUMENTS = ['acs', 'wfc3', 'stis', 'cos', 'wfpc2']
 
+
 def _get_reffile(hdr, key):
     """Get ref file from given key in given FITS header."""
     ref_file = None

--- a/ci_watson/hst_helpers.py
+++ b/ci_watson/hst_helpers.py
@@ -6,9 +6,8 @@ import shutil
 
 import crds
 
-__all__ = ['ref_from_image', 'raw_from_asn', 'download_crds']
 
-import shutil
+__all__ = ['ref_from_image', 'raw_from_asn', 'download_crds']
 
 CRDS_SERVER_URL = "https://hst-crds.stsci.edu"
 HST_INSTRUMENTS = ['acs', 'wfc3', 'stis', 'cos', 'wfpc2']
@@ -140,7 +139,7 @@ def download_crds(refname, timeout=30, verbose=False):
 
     # need to insure CRDS has been cached locally
     os.environ['CRDS_SERVER_URL'] = CRDS_SERVER_URL
-    os.environ['CRDS_PATH']='./'
+    os.environ['CRDS_PATH'] = '.' + os.sep
     # Make sure expected output directory is present in local directory
     tmpbase = os.path.join('references', 'hst')
     tmpref = os.path.join(tmpbase, HST_INSTRUMENTS[0])
@@ -153,7 +152,7 @@ def download_crds(refname, timeout=30, verbose=False):
                 os.mkdir(tmppath)
 
         # run the command to sync this CRDS file with local directory
-        sync_cmd = crds.sync.SyncScript('sync --files '+ fname)
+        sync_cmd = crds.sync.SyncScript('sync --files ' + fname)
         sync_cmd.sync_explicit_files()  # copies file into subdir
 
         # Move the sync'd reference file to locally defined directory now
@@ -163,7 +162,7 @@ def download_crds(refname, timeout=30, verbose=False):
         shutil.move(tmpfile, refname)
 
         if verbose:
-            print('Downloaded {} from {}'.format(refname, url))
+            print('Downloaded {} from {}'.format(refname, CRDS_SERVER_URL))
 
     except Exception:
         print(f"Failed to download {fname}")

--- a/ci_watson/hst_helpers.py
+++ b/ci_watson/hst_helpers.py
@@ -3,6 +3,7 @@
 import os
 import glob
 import shutil
+import warnings
 
 import crds
 
@@ -117,7 +118,7 @@ def download_crds(refname, timeout=30, verbose=False):
     """
     refdir = None
     fname = refname
-    print('Deprecation Warning: `timeout` parameter no longer needed.')
+    warnings.warn('Deprecation Warning: `timeout` parameter no longer needed.')
 
     # Expand IRAF-style dir shortcut.
     if '$' in refname:
@@ -139,8 +140,9 @@ def download_crds(refname, timeout=30, verbose=False):
         raise ValueError('Unknown HTTP destination for {}'.format(refname))
 
     # need to insure CRDS has been cached locally
-    os.environ['CRDS_SERVER_URL'] = CRDS_SERVER_URL
-    os.environ['CRDS_PATH'] = '.' + os.sep
+    if 'CRDS_SERVER_URL' not in os.environ:
+        os.environ['CRDS_SERVER_URL'] = CRDS_SERVER_URL
+        os.environ['CRDS_PATH'] = '.' + os.sep
     # Make sure expected output directory is present in local directory
     tmpbase = os.path.join('references', 'hst')
     tmpref = os.path.join(tmpbase, HST_INSTRUMENTS[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ setup_requires = setuptools_scm
 install_requires =
     pytest>=3
     requests
+    crds
 python_requires = >=3.5
 
 [options.packages.find]


### PR DESCRIPTION
This update replaces use of an informal URL and website with calls to CRDS for downloading HST reference files.  It is a 'transparent' replacement in that there are no API changes and no changes in behavior from the previous implementation.  