### PR TITLE
TST: Use Python 3.12 for devdeps

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,4 +32,6 @@ jobs:
         - linux: py310-slow-stable
 
         # Test with dev versions of upstream dependencies
-        - linux: py311-slow-devdeps
+        - linux: py312-slow-devdeps
+          python-version: '3.12-dev'
+          posargs: --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,build}
-    py{39,310,311}-test{,-slow}{,-stable,-devdeps}
+    py{39,310,311,312}-test{,-slow}{,-stable,-devdeps}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1


### PR DESCRIPTION
Fix #60 

Though I fear `crds` is going to make me grumpy. We'll see.