### PR TITLE
change type of `results_root` and `inputs_root` from `args` to `string`

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -38,14 +38,12 @@ def pytest_addoption(parser):
     parser.addini(
         "inputs_root",
         "Root dir (or data repository name) for test input files.",
-        type="args",
         default=None,
     )
 
     parser.addini(
         "results_root",
         "Root dir (or data repository name) for test result/output files.",
-        type="args",
         default=None,
     )
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,20 +59,20 @@ Example configuration within ``pytest.ini``::
   inputs_root = my_data_repo
   results_root = my_results_repo
 
-The value(s) defined in the pytest configuration file may be accessed as a list
+The value(s) defined in the pytest configuration file may be accessed as a string
 by test code via the ``pytestconfig`` fixture which must be passed in as an
 argument to the test method or function that will use the value.
 
 Example of accessing configuration values within test code itself::
 
   def test_important_thing(pytestconfig):
-      setup_cfg_inputs_root = pytestconfig.getini('inputs_root')[0]
+      setup_cfg_inputs_root = pytestconfig.getini('inputs_root')
       assert setup_cfg_inputs_root == 'my_data_repo'
       
 From within a fixture or a test class the configuration values must be accessed using a slightly different approach::
 
     import pytest
-    inputs_root = pytest.config.getini('inputs_root')[0]
+    inputs_root = pytest.config.getini('inputs_root')
 
 .. _bigdata_setup:
 

--- a/tests/test_artifactory_helpers.py
+++ b/tests/test_artifactory_helpers.py
@@ -59,7 +59,7 @@ class TestGetBigdata:
         self.root = get_bigdata_root()
 
     def test_nocopy(self, _jail, pytestconfig):
-        args = (pytestconfig.getini('inputs_root')[0],
+        args = (pytestconfig.getini('inputs_root'),
                 'dev',
                 'input',
                 'j6lq01010_asn.fits')
@@ -77,7 +77,7 @@ class TestGetBigdata:
         This tests download when TEST_BIGDATA is pointing to Artifactory.
         And tests copy when it is pointing to local path.
         """
-        args = (pytestconfig.getini('inputs_root')[0],
+        args = (pytestconfig.getini('inputs_root'),
                 'dev',
                 'input',
                 'j6lq01010_asn.fits')


### PR DESCRIPTION
resolves [SCSB-114](https://jira.stsci.edu/browse/SCSB-114)

this change could break downstream if people are assuming that `results_root` and `inputs_root` are passed as a list of strings