### PR TITLE
Update `tmpdir` usage to `tmp_path` and enable `no:legacypath`

### DIFF
--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -67,12 +67,12 @@ def pytest_runtest_setup(item):
 
 
 @pytest.fixture(scope='function')
-def _jail(tmpdir):
+def _jail(tmp_path):
     """Perform test in a pristine temporary working directory."""
     old_dir = os.getcwd()
-    os.chdir(tmpdir.strpath)
+    os.chdir(tmp_path)
     try:
-        yield tmpdir.strpath
+        yield str(tmp_path)
     finally:
         os.chdir(old_dir)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,4 +59,4 @@ junit_family = xunit2
 filterwarnings =
     error
     ignore:numpy.ndarray size changed:RuntimeWarning
-addopts = "-p no:legacypth"
+addopts = "-p no:legacypath"

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,3 +59,4 @@ junit_family = xunit2
 filterwarnings =
     error
     ignore:numpy.ndarray size changed:RuntimeWarning
+addopts = "-p no:legacypth"

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ requires =
 passenv = HOME,CI
 
 setenv =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/liberfa/simple
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -33,6 +33,7 @@ extras =
 
 deps =
     devdeps: numpy>=0.0.dev0
+    devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
 
 commands =


### PR DESCRIPTION
Usage of `tmpdir` in `ci_watson` prevents packages that use `ci_watson` from using the [`-p no:legacypath`](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures) pytest option to enforce `tmp_path` instead of `tmpdir` usage.

Although `_jail` is clearly marked with a leading underscore it is used in downstream:
https://github.com/search?q=repo%3Aspacetelescope%2Fjwst%20_jail&type=code
https://github.com/search?q=repo%3Aspacetelescope%2Fromancal%20_jail&type=code

This PR updates this package to use `tmp_path` instead of `tmpdir` and enables the `-p no:legacypath` option.

The failure of the `slow-devdeps` CI job also occurs on main and appears related to numpy 2.0.