### PR TITLE
Add fixtures for logging tracked resources to results.xml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.9.0 (unreleased)
+==================
+
+- Add ``resource_tracker`` and ``log_tracked_resources`` fixtures. [#74]
+
 0.8.0 (2024-12-09)
 ==================
 

--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -92,18 +92,20 @@ def resource_tracker():
     Use by calling ``track`` to generate a context in which resource
     usage will be tracked.
 
-    >>>
-    >> with resource_tracker.track():
-    >>     # do stuff
+    .. code-block:: python
+
+        with resource_tracker.track():
+            # do stuff
 
     For resources used during tests providing a function-scoped
     request fixture result as the log argument will also log the
     used resources to the junit results.xml.
 
-    >>>
-    >> def test_something(resource_tracker, request):
-    >>     with resource_tracker.track(log=request):
-    >>         # do stuff
+    .. code-block:: python
+
+        def test_something(resource_tracker, request):
+            with resource_tracker.track(log=request):
+                # do stuff
 
     For resources used during fixtures the tracked resources
     can be logged in a separate test using ``log_tracked_resources``.
@@ -115,14 +117,15 @@ def resource_tracker():
 def log_tracked_resources(resource_tracker, request):
     """Fixture to log resources tracked by ``resource_tracker``.
 
-    >>>
-    >> @pytest.fixture
-    >> def my_fixture(resource_tracker):
-    >>     with resource_tracker.track():
-    >>         # do stuff
-    >>
-    >> def test_write_log(log_tracked_resources, my_fixture):
-    >>     log_tracked_resources()
+    .. code-block:: python
+
+        @pytest.fixture
+        def my_fixture(resource_tracker):
+            with resource_tracker.track():
+                # do stuff
+
+        def test_write_log(log_tracked_resources, my_fixture):
+            log_tracked_resources()
     """
 
     def callback():

--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -5,6 +5,8 @@ pytest plugin.
 import os
 import pytest
 
+from ci_watson.resource_tracker import ResourceTracker
+
 __all__ = []
 
 
@@ -81,3 +83,50 @@ def _jail(tmp_path):
 def envopt(request):
     """Get the ``--env`` command-line option specifying test environment"""
     return request.config.getoption("env")
+
+
+@pytest.fixture(scope="module")
+def resource_tracker():
+    """Fixture to return the current module-scoped ResourceTracker.
+
+    Use by calling ``track`` to generate a context in which resource
+    usage will be tracked.
+
+    >>>
+    >> with resource_tracker.track():
+    >>     # do stuff
+
+    For resources used during tests providing a function-scoped
+    request fixture result as the log argument will also log the
+    used resources to the junit results.xml.
+
+    >>>
+    >> def test_something(resource_tracker, request):
+    >>     with resource_tracker.track(log=request):
+    >>         # do stuff
+
+    For resources used during fixtures the tracked resources
+    can be logged in a separate test using ``log_tracked_resources``.
+    """
+    return ResourceTracker()
+
+
+@pytest.fixture()
+def log_tracked_resources(resource_tracker, request):
+    """Fixture to log resources tracked by ``resource_tracker``.
+
+    >>>
+    >> @pytest.fixture
+    >> def my_fixture(resource_tracker):
+    >>     with resource_tracker.track():
+    >>         # do stuff
+    >>
+    >> def test_write_log(log_tracked_resources, my_fixture):
+    >>     log_tracked_resources()
+    """
+
+    def callback():
+        resource_tracker.log(request)
+
+    yield callback
+

--- a/ci_watson/resource_tracker.py
+++ b/ci_watson/resource_tracker.py
@@ -1,0 +1,110 @@
+"""Resource tracking regtest utilities
+
+Can be used within module-scoped fixtures (often used to
+run Steps or Pipelines) or within tests.
+
+For uses where the resource usage occurs within a test:
+
+>>>
+>> def test_long_step(resource_tracker, request):
+>>     with resource_tracker.track(log=request):
+>>         # something that takes memory and time
+>>         pass
+
+For a module-scoped fixture the resource tracking can
+be performed in the fixture but the logging/reporting of
+the resource usage must occur during a test:
+
+>>>
+>> @pytest.fixture(scope="module")
+>> def resource_tracker():
+>>     return ResourceTracker()
+>>
+>> @pytest.fixture()
+>> def log_tracked_resources(resource_tracker, request):
+>>     def callback():
+>>         resource_tracker.log(request)
+>>
+>>     yield callback
+>>
+>> @pytest.fixture
+>> def my_long_fixture(resource_tracker):
+>>     with resource_tracker.track():
+>>         # something that takes memory and time
+>>         pass
+>>
+>> def test_log_tracked_resources(log_tracked_resources, my_long_fixture):
+>>     log_tracked_resources()
+
+Use of the module-scoped fixture has fixture-reuse
+considerations similar to the ``rtdata_module`` fixture. Having
+more than one module scoped fixture that uses ``resource_tracker``
+per module is discouraged (as both will use the same ``ResourceTracker``
+instance). Parameterization of a fixture using ``resource_tracker``
+is supported (same as ``rtdata_module``).
+"""
+
+import time
+import tracemalloc
+from contextlib import ExitStack, contextmanager
+
+
+class TrackRuntime:
+    """Runtime tracker context."""
+
+    def __enter__(self):
+        self._t0 = time.monotonic()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.value = time.monotonic() - self._t0
+
+    def log(self):
+        return ("tracked-time", self.value)
+
+
+class TrackPeakMemory:
+    """Peak memory tracker context."""
+
+    def __enter__(self):
+        tracemalloc.start()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        _, self.value = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+    def log(self):
+        return ("tracked-peakmem", self.value)
+
+
+class ResourceTracker:
+    """Track resources used during track context."""
+
+    def __init__(self):
+        self._trackers = [TrackPeakMemory(), TrackRuntime()]
+
+    def log(self, request):
+        """Log tracked resource usage to the pytest request user properties.
+
+        Parameters
+        ----------
+        request : pytest.FixtureRequest
+            Must be a function-scoped pytest request fixture result.
+        """
+        request.node.user_properties.extend(t.log() for t in self._trackers)
+
+    @contextmanager
+    def track(self, log=None):
+        """Context during which resources are tracked.
+
+        Parameters
+        ----------
+        log : pytest.FixtureRequest, optional
+            If provided, log the usage to the provided request fixture result.
+        """
+        try:
+            with ExitStack() as stack:
+                [stack.enter_context(t) for t in self._trackers]
+                yield self
+        finally:
+            if log:
+                self.log(log)

--- a/ci_watson/resource_tracker.py
+++ b/ci_watson/resource_tracker.py
@@ -5,36 +5,38 @@ run Steps or Pipelines) or within tests.
 
 For uses where the resource usage occurs within a test:
 
->>>
->> def test_long_step(resource_tracker, request):
->>     with resource_tracker.track(log=request):
->>         # something that takes memory and time
->>         pass
+.. code-block:: python
+
+    def test_long_step(resource_tracker, request):
+        with resource_tracker.track(log=request):
+            # something that takes memory and time
+            pass
 
 For a module-scoped fixture the resource tracking can
 be performed in the fixture but the logging/reporting of
 the resource usage must occur during a test:
 
->>>
->> @pytest.fixture(scope="module")
->> def resource_tracker():
->>     return ResourceTracker()
->>
->> @pytest.fixture()
->> def log_tracked_resources(resource_tracker, request):
->>     def callback():
->>         resource_tracker.log(request)
->>
->>     yield callback
->>
->> @pytest.fixture
->> def my_long_fixture(resource_tracker):
->>     with resource_tracker.track():
->>         # something that takes memory and time
->>         pass
->>
->> def test_log_tracked_resources(log_tracked_resources, my_long_fixture):
->>     log_tracked_resources()
+.. code-block:: python
+
+    @pytest.fixture(scope="module")
+    def resource_tracker():
+        return ResourceTracker()
+
+    @pytest.fixture()
+    def log_tracked_resources(resource_tracker, request):
+        def callback():
+            resource_tracker.log(request)
+
+        yield callback
+
+    @pytest.fixture
+    def my_long_fixture(resource_tracker):
+        with resource_tracker.track():
+            # something that takes memory and time
+            pass
+
+    def test_log_tracked_resources(log_tracked_resources, my_long_fixture):
+        log_tracked_resources()
 
 Use of the module-scoped fixture has fixture-reuse
 considerations similar to the ``rtdata_module`` fixture. Having

--- a/ci_watson/resource_tracker.py
+++ b/ci_watson/resource_tracker.py
@@ -49,10 +49,10 @@ import tracemalloc
 from contextlib import ExitStack, contextmanager
 
 
-__all__ = ["TrackRuntime", "TrackPeakMemory", "ResourceTracker"]
+__all__ = ["ResourceTracker"]
 
 
-class TrackRuntime:
+class _TrackRuntime:
     """Runtime tracker context."""
 
     def __enter__(self):
@@ -65,7 +65,7 @@ class TrackRuntime:
         return ("tracked-time", self.value)
 
 
-class TrackPeakMemory:
+class _TrackPeakMemory:
     """Peak memory tracker context."""
 
     def __enter__(self):
@@ -83,7 +83,7 @@ class ResourceTracker:
     """Track resources used during track context."""
 
     def __init__(self):
-        self._trackers = [TrackPeakMemory(), TrackRuntime()]
+        self._trackers = [_TrackPeakMemory(), _TrackRuntime()]
 
     def log(self, request):
         """Log tracked resource usage to the pytest request user properties.

--- a/ci_watson/resource_tracker.py
+++ b/ci_watson/resource_tracker.py
@@ -49,6 +49,9 @@ import tracemalloc
 from contextlib import ExitStack, contextmanager
 
 
+__all__ = ["TrackRuntime", "TrackPeakMemory", "ResourceTracker"]
+
+
 class TrackRuntime:
     """Runtime tracker context."""
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,8 @@ The plugin portion of ``ci_watson`` contains:
   the author of the test to use this environment setting properly.
 * ``_jail`` fixture to enable a test to run in a pristine temporary working
   directory. This is particularly useful for pipeline tests.
+* ``resource_tracker`` and ``log_tracked_resources`` fixtures to track
+  memory and runtime and log them in the junit xml results file.
   
 Configuration Options
 ---------------------
@@ -99,4 +101,7 @@ Reference/API
     :no-inheritance-diagram:
 
 .. automodapi:: ci_watson.jwst_helpers
+    :no-inheritance-diagram:
+
+.. automodapi:: ci_watson.resource_tracker
     :no-inheritance-diagram:

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -1,0 +1,77 @@
+import os
+import time
+
+import pytest
+
+from ci_watson.resource_tracker import (
+    ResourceTracker,
+    TrackPeakMemory,
+    TrackRuntime,
+)
+
+
+class FakeNode:
+    def __init__(self):
+        self.user_properties = []
+
+
+class FakeRequest:
+    def __init__(self):
+        self.node = FakeNode()
+
+
+def test_runtime():
+    tracker = TrackRuntime()
+    with tracker:
+        time.sleep(1.0)
+    # a 1 second sleep is sometimes too much to ask
+    # of CI runners. Use a wide margin to make this test
+    # less brittle in those cases.
+    threshold = 0.5 if "CI" in os.environ else 0.1
+    assert abs(tracker.log()[1] - 1.0) < threshold
+
+
+def test_memory():
+    tracker = TrackPeakMemory()
+    N = 1024 * 1024
+    with tracker:
+        b = b"0" * N  # noqa: F841
+    assert abs(tracker.log()[1] - N) / N < 0.01
+
+
+def test_resource_tracker():
+    tracker = ResourceTracker()
+    with tracker.track():
+        pass
+    fake_request = FakeRequest()
+    tracker.log(fake_request)
+    keys = {log[0] for log in fake_request.node.user_properties}
+    assert keys == {"tracked-time", "tracked-peakmem"}
+
+
+def test_log():
+    tracker = ResourceTracker()
+    fake_request = FakeRequest()
+    with tracker.track(log=fake_request):
+        pass
+    keys = {log[0] for log in fake_request.node.user_properties}
+    assert keys == {"tracked-time", "tracked-peakmem"}
+
+
+@pytest.fixture(scope="module")
+def long_fixture(resource_tracker):
+    with resource_tracker.track():
+        pass
+
+
+def test_fixture_log_tracked_resources(log_tracked_resources, long_fixture, request):
+    log_tracked_resources()
+    keys = {log[0] for log in request.node.user_properties}
+    assert keys == {"tracked-time", "tracked-peakmem"}
+
+
+def test_fixutre_log_in_test(resource_tracker, request):
+    with resource_tracker.track(log=request):
+        pass
+    keys = {log[0] for log in request.node.user_properties}
+    assert keys == {"tracked-time", "tracked-peakmem"}

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -5,8 +5,8 @@ import pytest
 
 from ci_watson.resource_tracker import (
     ResourceTracker,
-    TrackPeakMemory,
-    TrackRuntime,
+    _TrackPeakMemory,
+    _TrackRuntime,
 )
 
 
@@ -21,7 +21,7 @@ class FakeRequest:
 
 
 def test_runtime():
-    tracker = TrackRuntime()
+    tracker = _TrackRuntime()
     with tracker:
         time.sleep(1.0)
     # a 1 second sleep is sometimes too much to ask
@@ -32,7 +32,7 @@ def test_runtime():
 
 
 def test_memory():
-    tracker = TrackPeakMemory()
+    tracker = _TrackPeakMemory()
     N = 1024 * 1024
     with tracker:
         b = b"0" * N  # noqa: F841


### PR DESCRIPTION
This PR adds fixtures for tracking and logging resource usage (peak memory and runtime) to the junit results.xml generated during regtest runs. The code is largely copied from romancal following https://github.com/spacetelescope/romancal/pull/1664 with a few added tests and docs.