### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 classifiers = [
     "Framework :: Pytest",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -22,6 +21,7 @@ dependencies = [
     "readchar>=3.0",
     "requests",
 ]
+license-files = ["LICENSE.md"]
 dynamic = [
     "version",
 ]
@@ -29,10 +29,6 @@ dynamic = [
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[project.license]
-file = "LICENSE.md"
-content-type = "text/plain"
 
 [project.urls]
 Homepage = "https://github.com/spacetelescope/ci_watson"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-license-files = [
-    "LICENSE.md",
-]
 
 [tool.setuptools.packages.find]
 exclude = [


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))