### PR TITLE
Revert "okify_regtests: Remove duplicates (#85)"

### DIFF
--- a/ci_watson/scripts/okify_regtests.py
+++ b/ci_watson/scripts/okify_regtests.py
@@ -203,14 +203,6 @@ def artifactory_download_run_files(
     return sorted(Path().rglob(f'*{suffix}'))
 
 
-def _rm_dup_files(file_paths: list[Path]) -> list[Path]:
-    """Remove duplicates if any, prefer last match."""
-    match = {}
-    for s in file_paths:
-        match[s.name] = s
-    return list(match.values())
-
-
 def artifactory_download_regtest_artifacts(
     observatory: Observatory,
     run_number: int,
@@ -249,9 +241,6 @@ def artifactory_download_regtest_artifacts(
 
     if len(specfiles) != len(asdffiles):
         raise RuntimeError("Different number of `_okify.json` and `_rtdata.asdf` files")
-
-    specfiles = _rm_dup_files(specfiles)
-    asdffiles = _rm_dup_files(asdffiles)
 
     for a, b in zip(specfiles, asdffiles):
         if str(a).replace(JSON_SPEC_FILE_SUFFIX, "") != str(b).replace(


### PR DESCRIPTION
This reverts commit a052dbb04d201c52febed57765348927c507b099.

The reverted commit caused okify issues for romancal run https://github.com/spacetelescope/RegressionTests/actions/runs/15737120210

Running okify on main only allows okifying 9 tests when 12 failed. Reverting this commit allows okifying all 12.

The asdf and spec files can have the same "name" but correspond to different tests when the test names match but the directories differ. This is often the case for romancal regtests.
https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/regression-tests/runs/2025-06-18_GITHUB_CI_Linux-X64-py3.11-2233/464_test_dq_init_image_step/test_dq_init_image_step_okify.json
and
https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/regression-tests/runs/2025-06-18_GITHUB_CI_Linux-X64-py3.11-2233/488_test_output_matches_truth/test_output_matches_truth_okify.json
is one example. With the reverted commit one of these gets ignored.