### PR TITLE
FEAT: okify_regtests to support HST RT

### DIFF
--- a/ci_watson/scripts/okify_regtests.py
+++ b/ci_watson/scripts/okify_regtests.py
@@ -22,6 +22,7 @@ TERMINAL_WIDTH = shutil.get_terminal_size((80, 20)).columns
 
 
 class Observatory(Enum):
+    hst = "hst"
     jwst = "jwst"
     roman = "roman"
 
@@ -31,7 +32,9 @@ class Observatory(Enum):
     @property
     def runs_directory(self) -> str:
         """Directory on Artifactory where run results are stored."""
-        if self == Observatory.jwst:
+        if self == Observatory.hst:
+            return "scsb-hstcal-results/"
+        elif self == Observatory.jwst:
             return "jwst-pipeline-results/"
         elif self == Observatory.roman:
             return "roman-pipeline-results/regression-tests/runs/"


### PR DESCRIPTION
I was naive. I thought https://github.com/spacetelescope/RegressionTests/pull/264 would let me use `okify_regtests` on HSTCAL RT but this patch as-is does not work. It is looking for

https://github.com/spacetelescope/ci_watson/blob/d42148349bca06663a996eba0ec6c27ed2795d3f/ci_watson/scripts/okify_regtests.py#L19-L20

but HSTCAL did not generate them in https://github.com/spacetelescope/RegressionTests/actions/runs/17445124814/job/49537640308 (https://bytesalad.stsci.edu/ui/repos/tree/General/scsb-hstcal-results/2025-09-03_GITHUB_CI_Linux-X64-py3.11-1073).

What else do I have to do, @zacharyburnett or @jhunkeler ?