### PR TITLE
Remove unused folder_copy option from okify_regtests

### DIFF
--- a/ci_watson/scripts/okify_regtests.py
+++ b/ci_watson/scripts/okify_regtests.py
@@ -353,10 +353,7 @@ def main():
                     except KeyError:
                         test_name = "test_name"
 
-                if okify_op == "folder_copy":
-                    ok_dst = truth_remote
-                    replace_whole_folders = True
-                elif okify_op == "sdp_pool_copy":
+                if okify_op == "sdp_pool_copy":
                     ok_dst = os.path.dirname(truth_remote)
                     replace_whole_folders = True
                 else:


### PR DESCRIPTION
This is no longer needed after https://github.com/spacetelescope/jwst/pull/9855 but we should wait for it to be removed completely from `jwst` first before merging this.

### Blocked by

* https://github.com/spacetelescope/jwst/pull/9870