### PR TITLE
Pytest skip slow

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -6,6 +6,10 @@ on:
     - main
     tags:
     - '*'
+  schedule:
+    # Weekly run on Mondays at 9am UTC
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 9 * * 1"
   pull_request:
 
 concurrency:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -33,3 +33,4 @@ jobs:
         # Test with dev versions of upstream dependencies
         - linux: py312-slow-devdeps
           posargs: --verbose
+        - linux: py312-slow-astropy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.12.0 (Unreleased)
+===================
+
+- Switch ``slow`` marker to use upstream ``pytest-skip-slow`` plugin instead of
+  the one defined in ``ci-watson``. [#105]
+
 0.11.0 (2026-02-06)
 ===================
 

--- a/ci_watson/plugin.py
+++ b/ci_watson/plugin.py
@@ -15,13 +15,6 @@ def pytest_addoption(parser):
     These pytest hooks allow us to mark tests and run the marked tests with
     specific command line options.
     """
-    # Add option to run slow tests
-    parser.addoption(
-        "--slow",
-        action="store_true",
-        help="run slow tests"
-    )
-
     # Add option to use big data sets
     parser.addoption(
         "--bigdata",
@@ -54,16 +47,10 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.getini('markers').append(
-        'slow: Run tests that are resource intensive')
-
-    config.getini('markers').append(
         'bigdata: Run tests that require intranet access')
 
 
 def pytest_runtest_setup(item):
-    if 'slow' in item.keywords and not item.config.getvalue("slow"):
-        pytest.skip("need --slow option to run")
-
     if 'bigdata' in item.keywords and not item.config.getvalue("bigdata"):
         pytest.skip("need --bigdata option to run")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "crds",
     "colorama>=0.4.1",
     "pytest>=9",
+    # Use upstream pytest-skip-slow to implement the slow marker
+    "pytest-skip-slow>=1.1.0",
     "readchar>=3.0",
     "requests",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,build}
-    py{310,311,312,313,314}-test{,-slow}{,-stable,-devdeps}
+    py{310,311,312,313,314}-test{,-slow}{-,astropy}{,-stable,-devdeps}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -26,6 +26,7 @@ description =
     slow: with slow flag
     stable: with env set to stable
     devdeps: with the latest developer version of key dependencies
+    astropy: Run with pytest-astropy plugin installed
 
 extras =
     test
@@ -34,6 +35,7 @@ extras =
 deps =
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+    astropy: pytest-astropy>=0.12.0
 
 commands =
     pip freeze


### PR DESCRIPTION
This does the following:

- Switches to using the `pytest-skip-slow` package for the slow pytest marker
- Adds `pytest-astropy` CI job so that we test agains that package as it has conflicted in the past.
- Adds a weekly cron job so we have a hope of catching issues before PRs get opened.

close #83